### PR TITLE
CI: do not use peaceiris/actions-gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 env:
-  artifact_name: "my-artifact"
   publish_dir: "doc/build/html"
   working_dir: "doc"  # only applies to `run` in steps
 
@@ -13,6 +12,18 @@ on:
       - develop
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -46,31 +57,21 @@ jobs:
         pipenv run make html
         rm -rf build/html/_sources
 
-    - name: Upload artifacts
+    - name: Upload artifact
+      id: deployment
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-pages-artifact@v3
       with:
-        name: ${{ env.artifact_name }}
-        path: |
-          ${{ env.publish_dir }}
-          !${{ env.publish_dir }}/_sources
+        path: ${{ env.publish_dir }}
 
   deploy:
+    environment:
+        name: github-pages
+        url: ${{ steps.deployment.outputs.page_url }}
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - name: Download artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.artifact_name }}
-        path: ${{ env.publish_dir }}
-
-    - name: Deploy artifacts
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        force_orphan: true
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ${{ env.publish_dir }}
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        user_name: 'github-actions[bot]'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

このコミットは次の障害を改善する可能性がある：

* `gh-pages` に格納した HTML ファイルに GitHub の外からアクセスすると内容が以前のまま変わらない。
