### PR TITLE
oh-my-posh: simplify code (#347)

### DIFF
--- a/doc/source/oh-my-posh.rst
+++ b/doc/source/oh-my-posh.rst
@@ -719,7 +719,6 @@ Template テキスト内では :samp:`.Env.{var}` で環境変数 `var` を参�
    function set_poshcontext() {
        export CURRENT_HISTORY_NUMBER="$HISTCMD"
    }
-   export -f set_poshcontext
 
 以上により、プロンプトに ``1096 $`` のような文字列が含まれるようになる。
 


### PR DESCRIPTION
## Summary

#347 で漏れていた修正。

## Checks

* [x] [CODE_OF_CONDUCT][conduct] を一読した
* [x] 関連する既存の issue がある場合、見出しまたは本文に `#xxx` を含めた
  （その issue を解決する場合、番号の前に close/fix/resolve キーワードを付けた）
* [x] 文書に手を入れた場合、誤字、脱字、ミススペリング、ミスマークアップ、その他不自然な修辞を新たに混入していない
* [x] プログラムコードに手を入れた場合、単体テストも変更、実施した

[conduct]: <https://github.com/showa-yojyo/.github/blob/main/CODE_OF_CONDUCT.md>
